### PR TITLE
Bring github repo up-to-date with current deployment

### DIFF
--- a/ansible/pico-web/tasks/dependencies.yml
+++ b/ansible/pico-web/tasks/dependencies.yml
@@ -26,6 +26,13 @@
     virtualenv: "{{ virtualenv_dir }}"
     virtualenv_python: python3.7
 
+- name: Install version of jinja2 with escape
+  pip:
+    name: jinja2
+    version: 3.0
+    virtualenv: "{{ virtualenv_dir }}"
+    virtualenv_python: python3.7
+
 - name: Install python packages in virtualenv
   pip:
     name: [

--- a/ansible/pico-web/tasks/dependencies.yml
+++ b/ansible/pico-web/tasks/dependencies.yml
@@ -29,7 +29,7 @@
 - name: Install version of jinja2 with escape
   pip:
     name: jinja2
-    version: 3.0
+    version: "3.0"
     virtualenv: "{{ virtualenv_dir }}"
     virtualenv_python: python3.7
 

--- a/problems/bundles/challenge-sampler.json
+++ b/problems/bundles/challenge-sampler.json
@@ -9,6 +9,5 @@
         "buffer-overflow-1-35e6d9d": 1
       }
     }
-    }
   }
 }


### PR DESCRIPTION
The jinja2 update comes directly from currently deployed infrastructure and allows the repo to work out of the box.

Additionally, the JSON file in /problems was updated to remove a stray closing bracket.